### PR TITLE
Remove versions from docfx.json

### DIFF
--- a/powershell-gallery/docfx.json
+++ b/powershell-gallery/docfx.json
@@ -139,11 +139,6 @@
         ]
       }
     ],
-    "template": [],
-    "versions": {
-      "powershellget-1.x": { "dest": "powershellget-1.x" },
-      "powershellget-2.x": { "dest": "powershellget-2.x" },
-      "powershellget-3.x": { "dest": "powershellget-3.x" }
-    }
+    "template": []
   }
 }


### PR DESCRIPTION
Trying to fix reference TOC
- Removed versions from docfx.json - prior to the change docfx has both versions and groups defined
