### PR TITLE
(GH-104) Fix `-Type` parameter in `Find-PSResource`

### DIFF
--- a/powershell-gallery/powershellget-3.x/Microsoft.PowerShell.PSResourceGet/Find-PSResource.md
+++ b/powershell-gallery/powershellget-3.x/Microsoft.PowerShell.PSResourceGet/Find-PSResource.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.PSResourceGet.dll-Help.xml
 Module Name: Microsoft.PowerShell.PSResourceGet
 ms.custom: 1.0.1
-ms.date: 11/10/2023
+ms.date: 01/17/2024
 online version: https://learn.microsoft.com/powershell/module/microsoft.powershell.psresourceget/find-psresource?view=powershellget-3.x&WT.mc_id=ps-gethelp
 schema: 2.0.0
 ---
@@ -343,10 +343,9 @@ Accept wildcard characters: False
 
 Specifies one or more resource types to find. Resource types supported are:
 
+- `None`
 - `Module`
 - `Script`
-- `Command`
-- `DscResource`
 
 ```yaml
 Type: Microsoft.PowerShell.PSResourceGet.UtilClasses.ResourceType


### PR DESCRIPTION
# PR Summary

Prior to this change, the reference documentation for the `-Type` parameter of the `Find-PSResource` cmdlet incorrectly listed `Command` and `DscResource` as valid options for the parameter.

This change:

- Removes the erroneous value options from the parameter docs
- Resolves #104
- Fixes [AB#200724](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/200724)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide