### PR TITLE
Fix typo in PSCredentialInfo type namespace

### DIFF
--- a/powershell-gallery/docs-conceptual/powershellget/how-to/credential-persistence.md
+++ b/powershell-gallery/docs-conceptual/powershellget/how-to/credential-persistence.md
@@ -47,7 +47,7 @@ $registerPSResourceRepositorySplat = @{
   Name = 'artifactory'
   Uri = 'https://myaccount.jfrog.io/artifactory/api/nuget/v3/myrepository'
   Trusted = $true
-  CredentialInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo]::new(
+  CredentialInfo = [Microsoft.PowerShell.PSResourceGet.UtilClasses.PSCredentialInfo]::new(
     'SecretStore', 'JFrogCred')
 }
 Register-PSResourceRepository @registerPSResourceRepositorySplat


### PR DESCRIPTION
While setting up PSResourceGet to install resources from an Azure artifact feed, I referenced these docs which threw the error `InvalidOperation: Unable to find type [Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo]`.

I swapped out "PowerShellGet" for "PSResourceGet" and the example worked like a charm.