### PR TITLE
Fixed typo in JSON example of required PSResource spec

### DIFF
--- a/powershell-gallery/powershellget-3.x/Microsoft.PowerShell.PSResourceGet/About/about_PSResourceGet.md
+++ b/powershell-gallery/powershellget-3.x/Microsoft.PowerShell.PSResourceGet/About/about_PSResourceGet.md
@@ -128,7 +128,7 @@ The next example shows the same specification in JSON format.
 ```json
 {
   "TestModule": {
-    "version": "[0.0.1,1.3.0)",
+    "version": "[0.0.1,1.3.0]",
     "repository": "PSGallery"
   },
   "TestModulePrerelease": {


### PR DESCRIPTION
# PR Summary

Changed closing bracket typo in JSON example of PSResource specification under [Searching by required resources](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.psresourceget/about/about_psresourceget?view=powershellget-3.x#searching-by-required-resources) section of about `PSResourceGet` doc.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide