### PR TITLE
Update Register-PSResourceRepository.md - Example 4

### DIFF
--- a/powershell-gallery/powershellget-3.x/Microsoft.PowerShell.PSResourceGet/Register-PSResourceRepository.md
+++ b/powershell-gallery/powershellget-3.x/Microsoft.PowerShell.PSResourceGet/Register-PSResourceRepository.md
@@ -115,12 +115,16 @@ PSGv3     https://www.powershellgallery.com/api/v3 True    50
 ### Example 4
 
 This example registers a repository with credential information to be retrieved from a registered
-**SecretManagement** vault, where **SecretStore** is the name of the vault and **TestSecret** is the name of the stored secret.
+**SecretManagement** vault, where **SecretStore** is the name of the vault and **TestSecret** is the
+name of the stored secret.
 
-You must have the **Microsoft.PowerShell.SecretManagement** module installed, have a registered vault, and stored a secret within it.
-If setup correctly, the command `Get-SecretInfo -Name 'TestSecret'` would return the secret.
+You must have the **Microsoft.PowerShell.SecretManagement** module installed, have a registered
+vault, and stored a secret within it. If setup correctly, the command
+`Get-SecretInfo -Name 'TestSecret'` would return the secret.
 
-Note: The format of the secret must match the requirements of the repository. In some instances, `TestSecret` might need storing as a **PSCredential** object with a username and password/token. In others it may need storing as a **SecureString** representing just the token.
+The format of the secret must match the requirements of the repository. In some instances,
+`TestSecret` might need storing as a **PSCredential** object with a username and password or token.
+In others it may need storing as a **SecureString** representing just the token.
 
 ```powershell
 $parameters = @{

--- a/powershell-gallery/powershellget-3.x/Microsoft.PowerShell.PSResourceGet/Register-PSResourceRepository.md
+++ b/powershell-gallery/powershellget-3.x/Microsoft.PowerShell.PSResourceGet/Register-PSResourceRepository.md
@@ -115,10 +115,12 @@ PSGv3     https://www.powershellgallery.com/api/v3 True    50
 ### Example 4
 
 This example registers a repository with credential information to be retrieved from a registered
-**SecretManagement** vault, where `SecretStore` is the name of the vault and `TestSecret` is the name of the stored secret.
+**SecretManagement** vault, where **SecretStore** is the name of the vault and **TestSecret** is the name of the stored secret.
+
 You must have the **Microsoft.PowerShell.SecretManagement** module installed, have a registered vault, and stored a secret within it.
 If setup correctly, the command `Get-SecretInfo -Name 'TestSecret'` would return the secret.
-Note: The format of the secret must match the requirements of the repository. In some instances, `TestSecret` might need storing as a PSCredential object with a username and password/token. In others it may need storing as a SecureString representing just the token.
+
+Note: The format of the secret must match the requirements of the repository. In some instances, `TestSecret` might need storing as a **PSCredential** object with a username and password/token. In others it may need storing as a **SecureString** representing just the token.
 
 ```powershell
 $parameters = @{

--- a/powershell-gallery/powershellget-3.x/Microsoft.PowerShell.PSResourceGet/Register-PSResourceRepository.md
+++ b/powershell-gallery/powershellget-3.x/Microsoft.PowerShell.PSResourceGet/Register-PSResourceRepository.md
@@ -115,9 +115,10 @@ PSGv3     https://www.powershellgallery.com/api/v3 True    50
 ### Example 4
 
 This example registers a repository with credential information to be retrieved from a registered
-**SecretManagement** vault. You must have the **Microsoft.PowerShell.SecretManagement** module
-installed and have a registered vault containing the stored secret. The format of the secret must
-match the requirements of the repository.
+**SecretManagement** vault, where `SecretStore` is the name of the vault and `TestSecret` is the name of the stored secret.
+You must have the **Microsoft.PowerShell.SecretManagement** module installed, have a registered vault, and stored a secret within it.
+If setup correctly, the command `Get-SecretInfo -Name 'TestSecret'` would return the secret.
+Note: The format of the secret must match the requirements of the repository. In some instances, `TestSecret` might need storing as a PSCredential object with a username and password/token. In others it may need storing as a SecureString representing just the token.
 
 ```powershell
 $parameters = @{


### PR DESCRIPTION
Relates to challenges faced getting started with registering package repositories using authentication, as detailed here: https://github.com/PowerShell/PSResourceGet/issues/1822

# PR Summary

Hopefully provides a little extra clarity for example 4. From my reading here it wasn't clear anywhere that the secret must be stored as a PSCredential object, and so I expected Find-PSResource to use the name of the secret and the value of the secret as username/password. This wasn't the case. 

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].
