### PR TITLE
Fixes #248 - Remove duplicate cdn

### DIFF
--- a/powershell-gallery/docs-conceptual/getting-started.md
+++ b/powershell-gallery/docs-conceptual/getting-started.md
@@ -134,7 +134,6 @@ Hosts required for package discovery and download:
 
 - `cdn.oneget.org`
 - `cdn.powershellgallery.com`
-- `cdn.powershellgallery.com`
 
 Hosts required when using the PowerShell Gallery website:
 


### PR DESCRIPTION
Remove duplicate cdn

- Fixes [AB#442829](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/442829)
- Fixes #248
